### PR TITLE
Use Environment Var for api-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ func makePCCRequest() error {
 
     cfg := openpcc.DefaultConfig()
     cfg.APIURL = "https://app.confident.security"
-    cfg.APIKey = "{Your API Key here}" //Read from ENVIRONMENT VAR (STRONGLY RECOMMEND)
+    cfg.APIKey = os.Getenv("<APIKEY_ENV_VAR_NAME>")
     cfg.TransparencyVerifier = transparency.DefaultVerifierConfig()
     cfg.TransparencyIdentityPolicy = &identityPolicy
 


### PR DESCRIPTION
Make sure users never set their API keys in source eventually ending up in distributed binary.

We assume users copy paste example code

Making sure the example code won't have no security issue even if it is copy pasted in to a production code.