### PR TITLE
Convert floating point usage to integer

### DIFF
--- a/anonpay/wallet/internal/test/account.go
+++ b/anonpay/wallet/internal/test/account.go
@@ -65,7 +65,7 @@ func (a *account) withdrawFull(t *testing.T, roundedFunc RoundedCurrencyFunc) (*
 		return nil, errors.New("balance is zero, can't withdraw full")
 	}
 
-	amount, err := roundedFunc(float64(a.balance))
+	amount, err := roundedFunc(uint64(a.balance))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rounded credit: %w", err)
 	}

--- a/anonpay/wallet/internal/test/bank.go
+++ b/anonpay/wallet/internal/test/bank.go
@@ -27,14 +27,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type RoundedCurrencyFunc func(signedAmount float64) (currency.Value, error)
+type RoundedCurrencyFunc func(signedAmount uint64) (currency.Value, error)
 
 func NewBlindBank(t *testing.T) (*inmem.Bank, *transfer.BlindBank) {
 	issuer := anonpaytest.MustNewIssuer()
 	payee := anonpaytest.MustNewPayee()
-	srcBank := inmem.NewBankWithRoundFunc(issuer, &anonpaytest.NoopNonceLocker{}, func(signedAmount float64) (currency.Value, error) {
+	srcBank := inmem.NewBankWithRoundFunc(issuer, &anonpaytest.NoopNonceLocker{}, func(signedAmount uint64) (currency.Value, error) {
 		// always round down in this test case for consistent results.
-		return currency.Rounded(signedAmount, 0)
+		return currency.RoundedInt(signedAmount, 0)
 	})
 	return srcBank, transfer.NewBlindBank(payee, srcBank)
 }
@@ -266,7 +266,7 @@ func splitBalanceExact(signedAmount int64) ([]currency.Value, error) {
 	remaining := signedAmount
 	for remaining > 0 {
 		n := min(remaining, currency.MaxAmount)
-		val, err := currency.Rounded(float64(n), 0.0)
+		val, err := currency.RoundedInt(uint64(n), 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to round %d down", n)
 		}


### PR DESCRIPTION
Please review and let me know if something like this might be acceptable, or if there is a reasonable path forward to be able to support using only integer math in an OpenPCC compliant implementation.

Note: This change was generated by gpt-oss-120b on 2 H200's running on Corvex Cloud hardware.