### PR TITLE
Fix multi key generation

### DIFF
--- a/gateway/keypairs.go
+++ b/gateway/keypairs.go
@@ -119,13 +119,12 @@ func (kps KeyPairs) FindSecretKey(ctx context.Context, header twoway.RequestHead
 
 func generateKeyPairs(seeds [][]byte) (KeyPairs, error) {
 	if len(seeds) > math.MaxUint8 {
-		return nil, fmt.Errorf("can at most generate %d keypairs, got %d seeds", math.MaxInt8, len(seeds))
+		return nil, fmt.Errorf("can at most generate %d keypairs, got %d seeds", math.MaxUint8, len(seeds))
 	}
-	seedsLen := byte(len(seeds))
 
 	kps := make(KeyPairs, 0, len(seeds))
-	for i := range seedsLen {
-		kps = append(kps, generateKeyPair(i, seeds[0], time.Now(), time.Now().AddDate(1, 0, 0)))
+	for i := range seeds {
+		kps = append(kps, generateKeyPair(byte(i), seeds[i], time.Now(), time.Now().AddDate(1, 0, 0)))
 	}
 
 	return kps, nil

--- a/gateway/keypairs_internal_test.go
+++ b/gateway/keypairs_internal_test.go
@@ -1,0 +1,56 @@
+package gateway
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateKeyPairs_Table(t *testing.T) {
+	tests := map[string]struct {
+		numSeeds    int
+		expErr      bool
+		expectedErr string
+	}{
+		"success with few seeds": {
+			numSeeds: 2,
+			expErr:   false,
+		},
+		"max allowed seeds": {
+			numSeeds: 255,
+			expErr:   false,
+		},
+		"fails exceeding maximum seeds": {
+			numSeeds: 256,
+			expErr:   true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			seeds := make([][]byte, tt.numSeeds)
+			for i := range seeds {
+				seeds[i] = bytes.Repeat([]byte{byte(i)}, 32)
+			}
+
+			kps, err := generateKeyPairs(seeds)
+
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, kps)
+			assert.Equal(t, tt.numSeeds, len(kps))
+
+			// ensure unique keys
+			idx := make(map[string]struct{}, len(kps))
+			for i := range kps {
+				pubKey, _ := kps[i].KeyConfig.PublicKey.MarshalBinary()
+				require.NotContains(t, idx, string(pubKey))
+				idx[string(pubKey)] = struct{}{}
+			}
+		})
+	}
+}


### PR DESCRIPTION
All generated key pairs will share the same underlying private key material, differing only by their `KeyID`. If the intention was to generate keys by providing multiple different seeds, this fails. 